### PR TITLE
Cambia el nombre de una variable

### DIFF
--- a/Ordenación_0.0.6BETA.FCMacro
+++ b/Ordenación_0.0.6BETA.FCMacro
@@ -35,7 +35,7 @@ if App.ActiveDocument.getObject(objetosSeleccionados[0].Name).InList: # Esto es 
             if (padre == ""):
                 padre = App.ActiveDocument.getObject(objeto.Name).InList[0].Name
             else:
-                padreDistinto = True
+                distintoPadre = True
                 break;
 else:
     tienePadre = False


### PR DESCRIPTION
La variable "padreDistinto" debe ser "distintoPadre" para que el funcionamiento de la macro sea el esperado.